### PR TITLE
Improve perappdeploy.cmd

### DIFF
--- a/bin/perappdeploy.cmd
+++ b/bin/perappdeploy.cmd
@@ -107,6 +107,11 @@
 @echo Done.
 @echo.
 
+@set continue_deploy=
+@set /p continue_deploy=Continue with deployment? (y=yes):
+@echo.
+@if /I NOT "%continue_deploy%"=="y" EXIT /b
+
 :askforappexe
 @set appexe=
 @set /p appexe=Application executable name with or without extension (optional, try leaving it blank first and only specify it if things don't work otherwise; it forces some programs to use Mesa3D which would otherwise bypass it):

--- a/bin/perappdeploy.cmd
+++ b/bin/perappdeploy.cmd
@@ -226,5 +226,7 @@
 
 :restart
 @set rerun=
+@echo.
 @set /p rerun=More Mesa deployment? (y=yes):
+@echo.
 @if /I "%rerun%"=="y" GOTO deploy


### PR DESCRIPTION
`perappdeploy.cmd` when run through Windows Terminal sometimes doesn't detect Ctrl-C reliably, this makes the batch file continue on after symlink deletion. Making it a bit sketchy when all I want is to just delete the symlinks.

The changes I propose implements **a pause before going into the deployment phase,** and will continue only if the user answers `y`.

In addition, I also added empty lines around the last question to make it stand out more.
