### PR TITLE
Allow deploy in docker container

### DIFF
--- a/bin/perappdeploy.cmd
+++ b/bin/perappdeploy.cmd
@@ -2,7 +2,7 @@
 @cd /d "%~dp0"
 @set "ERRORLEVEL="
 @CMD /C EXIT 0
-@"%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system" >nul 2>&1
+@"%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config" >nul 2>&1
 @if NOT "%ERRORLEVEL%"=="0" (
 @powershell -Command Start-Process """%0""" -Verb runAs 2>nul
 @exit

--- a/bin/systemwidedeploy.cmd
+++ b/bin/systemwidedeploy.cmd
@@ -2,7 +2,7 @@
 @cd /d "%~dp0"
 @set "ERRORLEVEL="
 @CMD /C EXIT 0
-@"%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system" >nul 2>&1
+@"%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config" >nul 2>&1
 @if NOT "%ERRORLEVEL%"=="0" (
 @IF "%*"=="" powershell -Command Start-Process """%0""" -Verb runAs 2>nul
 @IF NOT "%*"=="" powershell -Command Start-Process """%0""" """%*""" -Verb runAs 2>nul


### PR DESCRIPTION
The deploy scripts use
"%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system" to check for administrator privileges.
However, in a Windows docker container "%SYSTEMROOT%\system32\config\system" does not exist and hence the deploy scripts fail.
Removing \system fixes this while keeping functionallity since "%SYSTEMROOT%\system32\config" has the same file permissions.